### PR TITLE
Feature: Add gold layer sessions analysis models

### DIFF
--- a/services/orchestrator/src/dbt_project/models/marts/gold_session_candles.sql
+++ b/services/orchestrator/src/dbt_project/models/marts/gold_session_candles.sql
@@ -1,0 +1,22 @@
+with sessions as (
+    select * from (values
+        ('tokyo', '00:00'::time, '09:00'::time),
+        ('london', '08:00'::time, '17:00'::time),
+        ('new_york', '13:00'::time, '22:00'::time),
+        ('london_ny_overlap', '13:00'::time, '17:00'::time)
+    ) as s(session_name, session_start, session_end)
+)
+
+select
+    instrument,
+    candle_open::date as trading_date,
+    s.session_name,
+    first(open order by candle_open) as open,
+    max(high) as high,
+    min(low) as low,
+    last(close order by candle_open) as close
+from {{ ref('stg_ohlc_m1') }} m1
+join sessions s on
+    m1.candle_open::time >= s.session_start and
+    m1.candle_open::time < s.session_end
+group by instrument, candle_open, s.session_name

--- a/services/orchestrator/src/dbt_project/models/marts/gold_session_patterns.sql
+++ b/services/orchestrator/src/dbt_project/models/marts/gold_session_patterns.sql
@@ -1,0 +1,67 @@
+with session_order as (
+    select * from (values
+        ('tokyo', 1),
+        ('london', 2),
+        ('new_york', 3)
+    ) as r(session_name, session_order)
+),
+base as (
+    select
+        instrument,
+        trading_date,
+        session_name,
+        r.session_order,
+        open, high, low, close,
+        session_range,
+        true_range,
+        atr_5,
+        close_vs_range
+    from {{ ref('gold_session_stats') }} s
+    join session_order r on s.session_name = r.session_name
+    where session_name != 'london_ny_overlap'
+),
+prev as (
+    select
+        *,
+        lag(close, 1) over (
+            partition by instrument
+            order by trading_date, session_order
+        ) as prev_session_close,
+        lag(high, 1) over (
+            partition by instrument
+            order by trading_date, session_order
+        ) as prev_session_high,
+        lag(low, 1) over (
+            partition by instrument
+            order by trading_date, session_order
+        ) as prev_session_low
+    from base
+),
+session_break as (
+    select
+        *,
+        high > prev_session_high as broke_prev_high,
+        low < prev_session_low as broke_prev_low
+    from prev
+),
+vol_rank as (
+    select
+        *,
+        percent_rank() over (
+            partition by instrument, session_name
+            order by atr_5
+        ) as session_atr_rank
+    from session_break
+),
+vol_regime as (
+    select
+        *,
+        case
+            when atr_rank < 0.25 then 'low'
+            when atr_rank > 0.75 then 'high'
+            else 'normal'
+        end as session_vol_regime
+    from vol_rank
+)
+
+select * from vol_regime

--- a/services/orchestrator/src/dbt_project/models/marts/gold_session_stats.sql
+++ b/services/orchestrator/src/dbt_project/models/marts/gold_session_stats.sql
@@ -1,0 +1,30 @@
+with base as (
+    select
+        instrument,
+        trading_date,
+        session_name,
+        open, high, low, close,
+        (high - low) as session_range,
+        lag(close,1) over (
+            partition by instrument, session_name
+            order by trading_date
+        ) as prev_close
+    from {{ ref('gold_session_candles') }}
+),
+tr as (
+    select
+        *,
+        session_range / open * 100 as session_range_pct,
+        greatest(high-low, abs(high-prev_close), abs(low-prev_close)) as true_range,
+        (close - low) / NULLIF(session_range, 0) as close_vs_range
+    from base
+)
+
+select
+    *,
+    avg(true_range) over (
+        partition by instrument, session_name
+        order by trading_date
+        rows between 4 preceding and current row
+    ) as atr_5
+from tr


### PR DESCRIPTION
- Add `gold_session_candles`: aggregates m1 candles into forex trading sessions (Tokyo, London, NY, overlap) joining on session hour ranges
- Add `gold_session_stats`: computes per-session volatility metrics (ATR, true range, range %, close positioning) using layered CTEs and window functions
- Add `gold_session_patterns`: cross-session breakout detection (did this session break the previous session's high/low?) and ATR-based volatility regime classification using LAG, PERCENT_RANK, and CASE