### PR TITLE
Add dbt model and source documentation

### DIFF
--- a/services/orchestrator/src/dbt_project/models/intermediate/_schema.yml
+++ b/services/orchestrator/src/dbt_project/models/intermediate/_schema.yml
@@ -1,0 +1,131 @@
+version: 2
+
+models:
+  - name: int_ticks_unioned
+    description: "Unions tick data from all sources into a single stream, tagged with a source identifier."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: tick_time
+        data_type: timestamp with time zone
+        description: "Timestamp of the tick."
+
+      - name: bid
+        data_type: double
+        description: "Best bid price."
+
+      - name: ask
+        data_type: double
+        description: "Best ask price."
+
+      - name: mid
+        data_type: double
+        description: "Mid price."
+
+      - name: status
+        data_type: varchar
+        description: "Tick status from the source broker."
+
+      - name: source
+        data_type: varchar
+        description: "Data source identifier (e.g. 'oanda')."
+
+  - name: int_ticks_ny_adjusted
+    description: "Tick data with NY-close-aligned time fields. Shifts timestamps by the NY close hour (5pm ET) to derive the correct forex trading date."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: mid
+        data_type: double
+        description: "Mid price."
+
+      - name: bid
+        data_type: double
+        description: "Best bid price."
+
+      - name: ask
+        data_type: double
+        description: "Best ask price."
+
+      - name: tick_time
+        data_type: timestamp with time zone
+        description: "Original tick timestamp."
+
+      - name: shifted_ny
+        data_type: timestamp
+        description: "Tick time shifted by NY close offset. Used for time bucketing aligned to forex trading days."
+
+      - name: trading_date
+        data_type: date
+        description: "Forex trading date derived from the shifted NY time. Each day runs 5pm-to-5pm ET."
+
+  - name: int_m1_ny_adjusted
+    description: "1-minute candle data with NY-close-aligned time fields. Same shifting logic as int_ticks_ny_adjusted, applied to m1 candles for use by higher timeframe aggregations (H4, D1)."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: candle_open
+        data_type: timestamp with time zone
+        description: "Original candle open timestamp."
+
+      - name: open
+        data_type: double
+        description: "Mid open price."
+
+      - name: high
+        data_type: double
+        description: "Mid high price."
+
+      - name: low
+        data_type: double
+        description: "Mid low price."
+
+      - name: close
+        data_type: double
+        description: "Mid close price."
+
+      - name: bid_open
+        data_type: double
+        description: "Bid open price."
+
+      - name: bid_high
+        data_type: double
+        description: "Bid high price."
+
+      - name: bid_low
+        data_type: double
+        description: "Bid low price."
+
+      - name: bid_close
+        data_type: double
+        description: "Bid close price."
+
+      - name: ask_open
+        data_type: double
+        description: "Ask open price."
+
+      - name: ask_high
+        data_type: double
+        description: "Ask high price."
+
+      - name: ask_low
+        data_type: double
+        description: "Ask low price."
+
+      - name: ask_close
+        data_type: double
+        description: "Ask close price."
+
+      - name: shifted_ny
+        data_type: timestamp
+        description: "Candle open time shifted by NY close offset. Used for H4/D1 time bucketing."
+
+      - name: trading_date
+        data_type: date
+        description: "Forex trading date derived from the shifted NY time."

--- a/services/orchestrator/src/dbt_project/models/marts/_schema.yml
+++ b/services/orchestrator/src/dbt_project/models/marts/_schema.yml
@@ -1,0 +1,167 @@
+version: 2
+
+models:
+  - name: gold_session_candles
+    description: "OHLC candles aggregated by trading session. Defines four sessions (Tokyo, London, New York, London/NY overlap) and builds a single candle for each session per trading day."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: trading_date
+        data_type: date
+        description: "Calendar date of the trading session."
+
+      - name: session_name
+        data_type: varchar
+        description: "Trading session name: 'tokyo', 'london', 'new_york', or 'london_ny_overlap'."
+
+      - name: open
+        data_type: double
+        description: "Mid open price (first m1 candle in the session window)."
+
+      - name: high
+        data_type: double
+        description: "Mid high price (max across all m1 candles in the session)."
+
+      - name: low
+        data_type: double
+        description: "Mid low price (min across all m1 candles in the session)."
+
+      - name: close
+        data_type: double
+        description: "Mid close price (last M1 candle in the session window)."
+
+  - name: gold_session_stats
+    description: "Per-session trading statistics built on top of session candles. Adds range metrics, true range, close position within range, and a 5-period ATR."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: trading_date
+        data_type: date
+        description: "Calendar date of the trading session."
+
+      - name: session_name
+        data_type: varchar
+        description: "Trading session name."
+
+      - name: open
+        data_type: double
+        description: "Session mid open price."
+
+      - name: high
+        data_type: double
+        description: "Session mid high price."
+
+      - name: low
+        data_type: double
+        description: "Session mid low price."
+
+      - name: close
+        data_type: double
+        description: "Session mid close price."
+
+      - name: session_range
+        data_type: double
+        description: "Absolute session range (high - low)."
+
+      - name: prev_close
+        data_type: double
+        description: "Previous day's close for the same session, used for true range calculation."
+
+      - name: session_range_pct
+        data_type: double
+        description: "Session range as a percentage of the open price."
+
+      - name: true_range
+        data_type: double
+        description: "True range: max of (high-low, |high-prev_close|, |low-prev_close|)."
+
+      - name: close_vs_range
+        data_type: double
+        description: "Close position within the session range (0 = closed at low, 1 = closed at high). Null if range is zero."
+
+      - name: atr_5
+        data_type: double
+        description: "5-period average true range (rolling window over the last 5 sessions of the same type)."
+
+  - name: gold_session_patterns
+    description: "Cross-session pattern analysis. Compares each session against the previous session's levels to detect breakouts, and classifies volatility regimes based on ATR percentile rank. Excludes the London/NY overlap session."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: trading_date
+        data_type: date
+        description: "Calendar date of the trading session."
+
+      - name: session_name
+        data_type: varchar
+        description: "Trading session name: 'tokyo', 'london', or 'new_york'."
+
+      - name: session_order
+        data_type: integer
+        description: "Intraday session sequence (1=Tokyo, 2=London, 3=New York)."
+
+      - name: open
+        data_type: double
+        description: "Session mid open price."
+
+      - name: high
+        data_type: double
+        description: "Session mid high price."
+
+      - name: low
+        data_type: double
+        description: "Session mid low price."
+
+      - name: close
+        data_type: double
+        description: "Session mid close price."
+
+      - name: session_range
+        data_type: double
+        description: "Absolute session range (high - low)."
+
+      - name: true_range
+        data_type: double
+        description: "True range for the session."
+
+      - name: atr_5
+        data_type: double
+        description: "5-period average true range."
+
+      - name: close_vs_range
+        data_type: double
+        description: "Close position within the session range (0-1 scale)."
+
+      - name: prev_session_close
+        data_type: double
+        description: "Close price of the immediately preceding session (e.g. Tokyo close for London)."
+
+      - name: prev_session_high
+        data_type: double
+        description: "High of the immediately preceding session."
+
+      - name: prev_session_low
+        data_type: double
+        description: "Low of the immediately preceding session."
+
+      - name: broke_prev_high
+        data_type: boolean
+        description: "True if this session's high exceeded the previous session's high."
+
+      - name: broke_prev_low
+        data_type: boolean
+        description: "True if this session's low went below the previous session's low."
+
+      - name: session_atr_rank
+        data_type: double
+        description: "Percentile rank of this session's ATR relative to all sessions of the same type (0-1 scale)."
+
+      - name: session_vol_regime
+        data_type: varchar
+        description: "Volatility regime classification based on ATR rank: 'low' (<25th percentile), 'normal' (25th-75th), or 'high' (>75th)."

--- a/services/orchestrator/src/dbt_project/models/staging/_schema.yml
+++ b/services/orchestrator/src/dbt_project/models/staging/_schema.yml
@@ -1,0 +1,387 @@
+version: 2
+
+models:
+  - name: stg_oanda_ticks
+    description: "Staged tick data from Oanda. Extracts top-of-book bid/ask from nested arrays, calculates mid price, and filters to tradeable ticks only."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier (e.g. EUR_USD)."
+
+      - name: tick_time
+        data_type: timestamp with time zone
+        description: "Timestamp of the tick, cast to timestamptz."
+
+      - name: bid
+        data_type: double
+        description: "Best bid price (top of book)."
+
+      - name: ask
+        data_type: double
+        description: "Best ask price (top of book)."
+
+      - name: mid
+        data_type: double
+        description: "Mid price, calculated as average of bid and ask."
+
+      - name: status
+        data_type: varchar
+        description: "Tick status from Oanda. Always 'tradeable' after filtering."
+
+  - name: stg_ohlc_m1
+    description: "Staged 1-minute OHLC candles from Oanda. Renames source columns to standard mid/bid/ask naming convention."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: candle_open
+        data_type: timestamp with time zone
+        description: "Candle open timestamp (start of the 1-minute window)."
+
+      - name: open
+        data_type: double
+        description: "Mid open price."
+
+      - name: high
+        data_type: double
+        description: "Mid high price."
+
+      - name: low
+        data_type: double
+        description: "Mid low price."
+
+      - name: close
+        data_type: double
+        description: "Mid close price."
+
+      - name: bid_open
+        data_type: double
+        description: "Bid open price."
+
+      - name: bid_high
+        data_type: double
+        description: "Bid high price."
+
+      - name: bid_low
+        data_type: double
+        description: "Bid low price."
+
+      - name: bid_close
+        data_type: double
+        description: "Bid close price."
+
+      - name: ask_open
+        data_type: double
+        description: "Ask open price."
+
+      - name: ask_high
+        data_type: double
+        description: "Ask high price."
+
+      - name: ask_low
+        data_type: double
+        description: "Ask low price."
+
+      - name: ask_close
+        data_type: double
+        description: "Ask close price."
+
+      - name: tick_count
+        data_type: bigint
+        description: "Number of ticks within the 1-minute candle."
+
+  - name: stg_ohlc_m5
+    description: "5-minute OHLC candles, aggregated from 1-minute candles using time_bucket."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: candle_open
+        data_type: timestamp with time zone
+        description: "Candle open timestamp (start of the 5-minute window)."
+
+      - name: open
+        data_type: double
+        description: "Mid open price (first m1 open in the window)."
+
+      - name: high
+        data_type: double
+        description: "Mid high price (max m1 high in the window)."
+
+      - name: low
+        data_type: double
+        description: "Mid low price (min m1 low in the window)."
+
+      - name: close
+        data_type: double
+        description: "Mid close price (last m1 close in the window)."
+
+      - name: bid_open
+        data_type: double
+        description: "Bid open price."
+
+      - name: bid_high
+        data_type: double
+        description: "Bid high price."
+
+      - name: bid_low
+        data_type: double
+        description: "Bid low price."
+
+      - name: bid_close
+        data_type: double
+        description: "Bid close price."
+
+      - name: ask_open
+        data_type: double
+        description: "Ask open price."
+
+      - name: ask_high
+        data_type: double
+        description: "Ask high price."
+
+      - name: ask_low
+        data_type: double
+        description: "Ask low price."
+
+      - name: ask_close
+        data_type: double
+        description: "Ask close price."
+
+  - name: stg_ohlc_m15
+    description: "15-minute OHLC candles, aggregated from 1-minute candles using time_bucket."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: candle_open
+        data_type: timestamp with time zone
+        description: "Candle open timestamp (start of the 15-minute window)."
+
+      - name: open
+        data_type: double
+        description: "Mid open price (first m1 open in the window)."
+
+      - name: high
+        data_type: double
+        description: "Mid high price (max m1 high in the window)."
+
+      - name: low
+        data_type: double
+        description: "Mid low price (min m1 low in the window)."
+
+      - name: close
+        data_type: double
+        description: "Mid close price (last m1 close in the window)."
+
+      - name: bid_open
+        data_type: double
+        description: "Bid open price."
+
+      - name: bid_high
+        data_type: double
+        description: "Bid high price."
+
+      - name: bid_low
+        data_type: double
+        description: "Bid low price."
+
+      - name: bid_close
+        data_type: double
+        description: "Bid close price."
+
+      - name: ask_open
+        data_type: double
+        description: "Ask open price."
+
+      - name: ask_high
+        data_type: double
+        description: "Ask high price."
+
+      - name: ask_low
+        data_type: double
+        description: "Ask low price."
+
+      - name: ask_close
+        data_type: double
+        description: "Ask close price."
+
+  - name: stg_ohlc_h1
+    description: "1-hour OHLC candles, aggregated from 1-minute candles using time_bucket."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: candle_open
+        data_type: timestamp with time zone
+        description: "Candle open timestamp (start of the 1-hour window)."
+
+      - name: open
+        data_type: double
+        description: "Mid open price (first m1 open in the window)."
+
+      - name: high
+        data_type: double
+        description: "Mid high price (max m1 high in the window)."
+
+      - name: low
+        data_type: double
+        description: "Mid low price (min m1 low in the window)."
+
+      - name: close
+        data_type: double
+        description: "Mid close price (last m1 close in the window)."
+
+      - name: bid_open
+        data_type: double
+        description: "Bid open price."
+
+      - name: bid_high
+        data_type: double
+        description: "Bid high price."
+
+      - name: bid_low
+        data_type: double
+        description: "Bid low price."
+
+      - name: bid_close
+        data_type: double
+        description: "Bid close price."
+
+      - name: ask_open
+        data_type: double
+        description: "Ask open price."
+
+      - name: ask_high
+        data_type: double
+        description: "Ask high price."
+
+      - name: ask_low
+        data_type: double
+        description: "Ask low price."
+
+      - name: ask_close
+        data_type: double
+        description: "Ask close price."
+
+  - name: stg_ohlc_h4
+    description: "4-hour OHLC candles, aggregated from NY-adjusted 1-minute candles. Buckets are aligned to the NY close (5pm ET) to ensure candles don't split across trading days."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: candle_open
+        data_type: timestamp with time zone
+        description: "Candle open timestamp (start of the 4-hour window), aligned to NY close."
+
+      - name: open
+        data_type: double
+        description: "Mid open price (first m1 open in the window)."
+
+      - name: high
+        data_type: double
+        description: "Mid high price (max m1 high in the window)."
+
+      - name: low
+        data_type: double
+        description: "Mid low price (min m1 low in the window)."
+
+      - name: close
+        data_type: double
+        description: "Mid close price (last m1 close in the window)."
+
+      - name: bid_open
+        data_type: double
+        description: "Bid open price."
+
+      - name: bid_high
+        data_type: double
+        description: "Bid high price."
+
+      - name: bid_low
+        data_type: double
+        description: "Bid low price."
+
+      - name: bid_close
+        data_type: double
+        description: "Bid close price."
+
+      - name: ask_open
+        data_type: double
+        description: "Ask open price."
+
+      - name: ask_high
+        data_type: double
+        description: "Ask high price."
+
+      - name: ask_low
+        data_type: double
+        description: "Ask low price."
+
+      - name: ask_close
+        data_type: double
+        description: "Ask close price."
+
+  - name: stg_ohlc_d1
+    description: "Daily OHLC candles, aggregated from NY-adjusted 1-minute candles. Trading days are aligned to the NY close (5pm ET), matching forex market convention."
+    columns:
+      - name: instrument
+        data_type: varchar
+        description: "Currency pair identifier."
+
+      - name: candle_open
+        data_type: timestamp
+        description: "Candle open timestamp, representing the NY close that starts the trading day."
+
+      - name: open
+        data_type: double
+        description: "Mid open price (first m1 open of the trading day)."
+
+      - name: high
+        data_type: double
+        description: "Mid high price (max m1 high of the trading day)."
+
+      - name: low
+        data_type: double
+        description: "Mid low price (min m1 low of the trading day)."
+
+      - name: close
+        data_type: double
+        description: "Mid close price (last m1 close of the trading day)."
+
+      - name: bid_open
+        data_type: double
+        description: "Bid open price."
+
+      - name: bid_high
+        data_type: double
+        description: "Bid high price."
+
+      - name: bid_low
+        data_type: double
+        description: "Bid low price."
+
+      - name: bid_close
+        data_type: double
+        description: "Bid close price."
+
+      - name: ask_open
+        data_type: double
+        description: "Ask open price."
+
+      - name: ask_high
+        data_type: double
+        description: "Ask high price."
+
+      - name: ask_low
+        data_type: double
+        description: "Ask low price."
+
+      - name: ask_close
+        data_type: double
+        description: "Ask close price."

--- a/services/orchestrator/src/dbt_project/models/staging/_sources.yml
+++ b/services/orchestrator/src/dbt_project/models/staging/_sources.yml
@@ -2,11 +2,65 @@ version: 2
 
 sources:
   - name: forex
+    description: "Raw forex market data from broker APIs, landed in the bronze layer as Parquet files."
     schema: main
     tables:
       - name: oanda_ticks
+        description: "Raw tick-level price updates streamed from the Oanda v20 API. Each row is a single price tick containing depth-of-book bid/ask levels."
         meta:
           external_location: "{{ env_var('DATA_ROOT') }}/bronze/ticks/oanda/*/*.parquet"
+        columns:
+          - name: type
+            description: "Tick type from Oanda (always 'PRICE' for price ticks)."
+          - name: time
+            description: "ISO 8601 timestamp string from Oanda indicating when the tick was generated."
+          - name: bids
+            description: "Depth-of-book bid levels. List of structs, each containing a 'price' (string) and 'liquidity' (integer)."
+          - name: asks
+            description: "Depth-of-book ask levels. List of structs, each containing a 'price' (string) and 'liquidity' (integer)."
+          - name: closeoutBid
+            description: "Closeout bid price as a string. Used by Oanda for margin closeout calculations."
+          - name: closeoutAsk
+            description: "Closeout ask price as a string. Used by Oanda for margin closeout calculations."
+          - name: status
+            description: "Market status for the instrument (e.g. 'tradeable', 'non-tradeable')."
+          - name: tradeable
+            description: "Boolean flag indicating whether the instrument is currently tradeable."
+          - name: instrument
+            description: "Currency pair identifier (e.g. 'EUR_USD')."
+
       - name: oanda_m1
+        description: "1-minute OHLC candles constructed by the candle_builder service from raw tick data. Each row is a single completed M1 candle with bid, ask, and mid prices."
         meta:
           external_location: "{{ env_var('DATA_ROOT') }}/bronze/ohlc_m1/*/*.parquet"
+        columns:
+          - name: instrument
+            description: "Currency pair identifier (e.g. 'EUR_USD')."
+          - name: bucket
+            description: "Candle open timestamp (start of the 1-minute window), in UTC."
+          - name: bid_open
+            description: "Bid open price for the candle."
+          - name: bid_high
+            description: "Highest bid price during the candle."
+          - name: bid_low
+            description: "Lowest bid price during the candle."
+          - name: bid_close
+            description: "Bid close price for the candle."
+          - name: ask_open
+            description: "Ask open price for the candle."
+          - name: ask_high
+            description: "Highest ask price during the candle."
+          - name: ask_low
+            description: "Lowest ask price during the candle."
+          - name: ask_close
+            description: "Ask close price for the candle."
+          - name: mid_open
+            description: "Mid open price (average of bid and ask open)."
+          - name: mid_high
+            description: "Mid high price (average of bid and ask high)."
+          - name: mid_low
+            description: "Mid low price (average of bid and ask low)."
+          - name: mid_close
+            description: "Mid close price (average of bid and ask close)."
+          - name: tick_count
+            description: "Number of ticks received during the 1-minute window."

--- a/services/orchestrator/src/dbt_project/package-lock.yml
+++ b/services/orchestrator/src/dbt_project/package-lock.yml
@@ -1,0 +1,8 @@
+packages:
+  - name: codegen
+    package: dbt-labs/codegen
+    version: 0.14.0
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.3.3
+sha1_hash: 2dff701aabc559b9b3367da24bc784c145664fd3

--- a/services/orchestrator/src/dbt_project/packages.yml
+++ b/services/orchestrator/src/dbt_project/packages.yml
@@ -1,0 +1,3 @@
+packages:
+  - package: dbt-labs/codegen
+    version: 0.14.0

--- a/services/orchestrator/src/orchestrator/defs/assets/oanda_m1.py
+++ b/services/orchestrator/src/orchestrator/defs/assets/oanda_m1.py
@@ -4,4 +4,10 @@ oanda_m1 = dg.AssetSpec(
     key="oanda_m1",
     description="m1 OHLC candles produced by candle_builder service",
     group_name="bronze",
+    owners=["team:data-engineering"],
+    tags={"domain": "forex", "cadence": "streaming"},
+    metadata={
+        "source_service": "candle_builder",
+        "update_cadence": "Every 60s during market hours",
+    },
 )

--- a/services/orchestrator/src/orchestrator/defs/assets/oanda_ticks.py
+++ b/services/orchestrator/src/orchestrator/defs/assets/oanda_ticks.py
@@ -1,13 +1,19 @@
 import dagster as dg
-from orchestrator.lib.compaction import compact_files
 
 from orchestrator.defs.partitions import tick_partition
 from orchestrator.defs.resources import DataPathsResource
+from orchestrator.lib.compaction import compact_files
 
 landing_ticks = dg.AssetSpec(
     key="landing_ticks",
     description="Raw tick data written by stream_writer service",
     group_name="landing",
+    owners=["team:data-engineering"],
+    tags={"domain": "forex", "cadence": "streaming"},
+    metadata={
+        "source_service": "stream_writer",
+        "update_cadence": "Continuous during market hours",
+    },
 )
 
 
@@ -17,6 +23,8 @@ landing_ticks = dg.AssetSpec(
     description="Deduplicated daily tick data in the bronze layer, partitioned by instrument",
     group_name="bronze",
     kinds={"parquet"},
+    owners=["team:data-engineering"],
+    tags={"domain": "forex", "cadence": "daily"},
 )
 def oanda_ticks(
     context: dg.AssetExecutionContext,


### PR DESCRIPTION
Improve documentation both from the viewpoint of dbt models and dagster assets. 

- Add `_schema.yml` files with model and column descriptions for all dbt layers (staging, intermediate, marts)
- Add source and column-level documentation to `_sources.yml` for the `oanda_ticks` and `oanda_m1` bronze sources
- Add `dbt-codegen` package for schema generation tooling
- Add tags and metadata to source tables

Closes #39 