### PR TITLE
Feature: Add bronze layer dagster sensor and job to trigger dbt build.

### DIFF
--- a/services/orchestrator/entrypoint.sh
+++ b/services/orchestrator/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -e
 
+echo "Installing dbt packages..."
+dbt deps --project-dir /app/src/dbt_project --profiles-dir /app/src/dbt_project
+
 echo "Generating dbt manifest..."
 dbt parse --project-dir /app/src/dbt_project --profiles-dir /app/src/dbt_project
 

--- a/services/orchestrator/src/orchestrator/defs/jobs.py
+++ b/services/orchestrator/src/orchestrator/defs/jobs.py
@@ -7,5 +7,7 @@ compaction_job = dg.define_asset_job(name="compaction_job", selection=compaction
 
 dbt_ohlc_build = dg.AssetSelection.assets(dbt_project_assets)
 dbt_ohlc_build_job = dg.define_asset_job(
-    name="dbt_ohlc_build_job", selection=dbt_ohlc_build
+    name="dbt_ohlc_build_job",
+    selection=dbt_ohlc_build,
+    description="Runs `dbt build` to materialise OHLC models from bronze m1 candle data.",
 )

--- a/services/orchestrator/src/orchestrator/defs/jobs.py
+++ b/services/orchestrator/src/orchestrator/defs/jobs.py
@@ -1,9 +1,11 @@
 import dagster as dg
 
+from orchestrator.defs.dbt_assets import dbt_project_assets
+
 compaction = dg.AssetSelection.assets("oanda_ticks")
 compaction_job = dg.define_asset_job(name="compaction_job", selection=compaction)
 
-dbt_ohlc_build = dg.AssetSelection.assets("dbt_project_assets")
+dbt_ohlc_build = dg.AssetSelection.assets(dbt_project_assets)
 dbt_ohlc_build_job = dg.define_asset_job(
     name="dbt_ohlc_build_job", selection=dbt_ohlc_build
 )

--- a/services/orchestrator/src/orchestrator/defs/jobs.py
+++ b/services/orchestrator/src/orchestrator/defs/jobs.py
@@ -1,5 +1,9 @@
 import dagster as dg
 
 compaction = dg.AssetSelection.assets("oanda_ticks")
-
 compaction_job = dg.define_asset_job(name="compaction_job", selection=compaction)
+
+dbt_ohlc_build = dg.AssetSelection.assets("dbt_project_assets")
+dbt_ohlc_build_job = dg.define_asset_job(
+    name="dbt_ohlc_build_job", selection=dbt_ohlc_build
+)

--- a/services/orchestrator/src/orchestrator/defs/sensors.py
+++ b/services/orchestrator/src/orchestrator/defs/sensors.py
@@ -1,15 +1,16 @@
-import dagster as dg
 import os
 from pathlib import Path
+
+import dagster as dg
+
 from orchestrator.defs.jobs import dbt_ohlc_build_job
 
 BRONZE_OHLC_DIR = Path(os.environ["DATA_ROOT"]) / "bronze" / "ohlc_m1"
 
-@dg.sensor(job=dbt_ohlc_build_job, minimum_interval_seconds=60)
+
+@dg.sensor(job=dbt_ohlc_build_job, minimum_interval_seconds=300)
 def bronze_ohlc_sensor(context: dg.SensorEvaluationContext):
-    all_files = sorted(
-        str(f.name) for f in BRONZE_OHLC_DIR.rglob("*.parquet")
-    )
+    all_files = sorted(str(f.name) for f in BRONZE_OHLC_DIR.rglob("*.parquet"))
 
     if not all_files:
         yield dg.SkipReason("No parquet files found in bronze OHLC directory")

--- a/services/orchestrator/src/orchestrator/defs/sensors.py
+++ b/services/orchestrator/src/orchestrator/defs/sensors.py
@@ -1,0 +1,27 @@
+import dagster as dg
+import os
+from pathlib import Path
+from orchestrator.defs.jobs import dbt_ohlc_build_job
+
+BRONZE_OHLC_DIR = Path(os.environ["DATA_ROOT"]) / "bronze" / "ohlc_m1"
+
+@dg.sensor(job=dbt_ohlc_build_job, minimum_interval_seconds=60)
+def bronze_ohlc_sensor(context: dg.SensorEvaluationContext):
+    all_files = sorted(
+        str(f.name) for f in BRONZE_OHLC_DIR.rglob("*.parquet")
+    )
+
+    if not all_files:
+        yield dg.SkipReason("No parquet files found in bronze OHLC directory")
+        return
+
+    cursor = context.cursor
+    new_files = [f for f in all_files if f > cursor] if cursor else all_files
+
+    if not new_files:
+        yield dg.SkipReason("No new parquet files since last run")
+        return
+
+    latest = new_files[-1]
+    context.update_cursor(latest)
+    yield dg.RunRequest(run_key=f"dbt_ohlc_{latest}")


### PR DESCRIPTION
Automates the triggering of dbt build via new dagster job `dbt_ohlc_build_job`.

A new sensor, `bronze_ohlc_sensor` watches `/bronze/ohlc_m1` folder for new files. By default it checks every 5 minutes. 

Files are currently delivered every 15 minutes but using a sensor instead of a schedule allows for an event-driven approach and decouples the build schedule from the flush interval.

Closes #33 