### PR TITLE
Feature: Add dbt data quality tests

### DIFF
--- a/services/orchestrator/src/dbt_project/models/intermediate/_schema.yml
+++ b/services/orchestrator/src/dbt_project/models/intermediate/_schema.yml
@@ -3,129 +3,205 @@ version: 2
 models:
   - name: int_ticks_unioned
     description: "Unions tick data from all sources into a single stream, tagged with a source identifier."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - instrument
+            - tick_time
+            - source
     columns:
       - name: instrument
         data_type: varchar
         description: "Currency pair identifier."
+        tests:
+          - not_null
 
       - name: tick_time
         data_type: timestamp with time zone
         description: "Timestamp of the tick."
+        tests:
+          - not_null
 
       - name: bid
         data_type: double
         description: "Best bid price."
+        tests:
+          - not_null
 
       - name: ask
         data_type: double
         description: "Best ask price."
+        tests:
+          - not_null
 
       - name: mid
         data_type: double
         description: "Mid price."
+        tests:
+          - not_null
 
       - name: status
         data_type: varchar
         description: "Tick status from the source broker."
+        tests:
+          - not_null
 
       - name: source
         data_type: varchar
         description: "Data source identifier (e.g. 'oanda')."
+        tests:
+          - not_null
 
   - name: int_ticks_ny_adjusted
     description: "Tick data with NY-close-aligned time fields. Shifts timestamps by the NY close hour (5pm ET) to derive the correct forex trading date."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - instrument
+            - tick_time
     columns:
       - name: instrument
         data_type: varchar
         description: "Currency pair identifier."
+        tests:
+          - not_null
 
       - name: mid
         data_type: double
         description: "Mid price."
+        tests:
+          - not_null
 
       - name: bid
         data_type: double
         description: "Best bid price."
+        tests:
+          - not_null
 
       - name: ask
         data_type: double
         description: "Best ask price."
+        tests:
+          - not_null
 
       - name: tick_time
         data_type: timestamp with time zone
         description: "Original tick timestamp."
+        tests:
+          - not_null
 
       - name: shifted_ny
         data_type: timestamp
         description: "Tick time shifted by NY close offset. Used for time bucketing aligned to forex trading days."
+        tests:
+          - not_null
 
       - name: trading_date
         data_type: date
         description: "Forex trading date derived from the shifted NY time. Each day runs 5pm-to-5pm ET."
+        tests:
+          - not_null
 
   - name: int_m1_ny_adjusted
     description: "1-minute candle data with NY-close-aligned time fields. Same shifting logic as int_ticks_ny_adjusted, applied to m1 candles for use by higher timeframe aggregations (H4, D1)."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - instrument
+            - candle_open
     columns:
       - name: instrument
         data_type: varchar
         description: "Currency pair identifier."
+        tests:
+          - not_null
 
       - name: candle_open
         data_type: timestamp with time zone
         description: "Original candle open timestamp."
+        tests:
+          - not_null
 
       - name: open
         data_type: double
         description: "Mid open price."
+        tests:
+          - not_null
 
       - name: high
         data_type: double
         description: "Mid high price."
+        tests:
+          - not_null
 
       - name: low
         data_type: double
         description: "Mid low price."
+        tests:
+          - not_null
 
       - name: close
         data_type: double
         description: "Mid close price."
+        tests:
+          - not_null
 
       - name: bid_open
         data_type: double
         description: "Bid open price."
+        tests:
+          - not_null
 
       - name: bid_high
         data_type: double
         description: "Bid high price."
+        tests:
+          - not_null
 
       - name: bid_low
         data_type: double
         description: "Bid low price."
+        tests:
+          - not_null
 
       - name: bid_close
         data_type: double
         description: "Bid close price."
+        tests:
+          - not_null
 
       - name: ask_open
         data_type: double
         description: "Ask open price."
+        tests:
+          - not_null
 
       - name: ask_high
         data_type: double
         description: "Ask high price."
+        tests:
+          - not_null
 
       - name: ask_low
         data_type: double
         description: "Ask low price."
+        tests:
+          - not_null
 
       - name: ask_close
         data_type: double
         description: "Ask close price."
+        tests:
+          - not_null
 
       - name: shifted_ny
         data_type: timestamp
         description: "Candle open time shifted by NY close offset. Used for H4/D1 time bucketing."
+        tests:
+          - not_null
 
       - name: trading_date
         data_type: date
         description: "Forex trading date derived from the shifted NY time."
+        tests:
+          - not_null

--- a/services/orchestrator/src/dbt_project/models/marts/_schema.yml
+++ b/services/orchestrator/src/dbt_project/models/marts/_schema.yml
@@ -3,69 +3,117 @@ version: 2
 models:
   - name: gold_session_candles
     description: "OHLC candles aggregated by trading session. Defines four sessions (Tokyo, London, New York, London/NY overlap) and builds a single candle for each session per trading day."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - instrument
+            - trading_date
+            - session_name
     columns:
       - name: instrument
         data_type: varchar
         description: "Currency pair identifier."
+        tests:
+          - not_null
 
       - name: trading_date
         data_type: date
         description: "Calendar date of the trading session."
+        tests:
+          - not_null
 
       - name: session_name
         data_type: varchar
         description: "Trading session name: 'tokyo', 'london', 'new_york', or 'london_ny_overlap'."
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - "tokyo"
+                - "london"
+                - "new_york"
+                - "london_ny_overlap"
 
       - name: open
         data_type: double
         description: "Mid open price (first m1 candle in the session window)."
+        tests:
+          - not_null
 
       - name: high
         data_type: double
         description: "Mid high price (max across all m1 candles in the session)."
+        tests:
+          - not_null
 
       - name: low
         data_type: double
         description: "Mid low price (min across all m1 candles in the session)."
+        tests:
+          - not_null
 
       - name: close
         data_type: double
         description: "Mid close price (last M1 candle in the session window)."
+        tests:
+          - not_null
 
   - name: gold_session_stats
     description: "Per-session trading statistics built on top of session candles. Adds range metrics, true range, close position within range, and a 5-period ATR."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - instrument
+            - trading_date
+            - session_name
     columns:
       - name: instrument
         data_type: varchar
         description: "Currency pair identifier."
+        tests:
+          - not_null
 
       - name: trading_date
         data_type: date
         description: "Calendar date of the trading session."
+        tests:
+          - not_null
 
       - name: session_name
         data_type: varchar
         description: "Trading session name."
+        tests:
+          - not_null
 
       - name: open
         data_type: double
         description: "Session mid open price."
+        tests:
+          - not_null
 
       - name: high
         data_type: double
         description: "Session mid high price."
+        tests:
+          - not_null
 
       - name: low
         data_type: double
         description: "Session mid low price."
+        tests:
+          - not_null
 
       - name: close
         data_type: double
         description: "Session mid close price."
+        tests:
+          - not_null
 
       - name: session_range
         data_type: double
         description: "Absolute session range (high - low)."
+        tests:
+          - not_null
 
       - name: prev_close
         data_type: double
@@ -74,10 +122,14 @@ models:
       - name: session_range_pct
         data_type: double
         description: "Session range as a percentage of the open price."
+        tests:
+          - not_null
 
       - name: true_range
         data_type: double
         description: "True range: max of (high-low, |high-prev_close|, |low-prev_close|)."
+        tests:
+          - not_null
 
       - name: close_vs_range
         data_type: double
@@ -86,53 +138,90 @@ models:
       - name: atr_5
         data_type: double
         description: "5-period average true range (rolling window over the last 5 sessions of the same type)."
+        tests:
+          - not_null
 
   - name: gold_session_patterns
     description: "Cross-session pattern analysis. Compares each session against the previous session's levels to detect breakouts, and classifies volatility regimes based on ATR percentile rank. Excludes the London/NY overlap session."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - instrument
+            - trading_date
+            - session_name
     columns:
       - name: instrument
         data_type: varchar
         description: "Currency pair identifier."
+        tests:
+          - not_null
 
       - name: trading_date
         data_type: date
         description: "Calendar date of the trading session."
+        tests:
+          - not_null
 
       - name: session_name
         data_type: varchar
         description: "Trading session name: 'tokyo', 'london', or 'new_york'."
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - "tokyo"
+                - "london"
+                - "new_york"
 
       - name: session_order
         data_type: integer
         description: "Intraday session sequence (1=Tokyo, 2=London, 3=New York)."
+        tests:
+          - not_null
+          - accepted_values:
+              values: [1, 2, 3]
 
       - name: open
         data_type: double
         description: "Session mid open price."
+        tests:
+          - not_null
 
       - name: high
         data_type: double
         description: "Session mid high price."
+        tests:
+          - not_null
 
       - name: low
         data_type: double
         description: "Session mid low price."
+        tests:
+          - not_null
 
       - name: close
         data_type: double
         description: "Session mid close price."
+        tests:
+          - not_null
 
       - name: session_range
         data_type: double
         description: "Absolute session range (high - low)."
+        tests:
+          - not_null
 
       - name: true_range
         data_type: double
         description: "True range for the session."
+        tests:
+          - not_null
 
       - name: atr_5
         data_type: double
         description: "5-period average true range."
+        tests:
+          - not_null
 
       - name: close_vs_range
         data_type: double
@@ -161,7 +250,16 @@ models:
       - name: session_atr_rank
         data_type: double
         description: "Percentile rank of this session's ATR relative to all sessions of the same type (0-1 scale)."
+        tests:
+          - not_null
 
       - name: session_vol_regime
         data_type: varchar
         description: "Volatility regime classification based on ATR rank: 'low' (<25th percentile), 'normal' (25th-75th), or 'high' (>75th)."
+        tests:
+          - not_null
+          - accepted_values:
+              values:
+                - "low"
+                - "normal"
+                - "high"

--- a/services/orchestrator/src/dbt_project/tests/assert_gold_session_candles_ohlc_invariants.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_gold_session_candles_ohlc_invariants.sql
@@ -1,0 +1,8 @@
+select *
+from {{ ref('gold_session_candles') }}
+where
+    high < low or
+    high < open or
+    high < close or
+    low > open or
+    low > close

--- a/services/orchestrator/src/dbt_project/tests/assert_gold_session_patterns_derived_metrics.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_gold_session_patterns_derived_metrics.sql
@@ -1,0 +1,5 @@
+select *
+from {{ ref ('gold_session_patterns') }}
+where
+    session_atr_rank < 0 or
+    session_atr_rank > 1

--- a/services/orchestrator/src/dbt_project/tests/assert_gold_session_stats_derived_metrics.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_gold_session_stats_derived_metrics.sql
@@ -1,0 +1,8 @@
+select *
+from {{ ref ('gold_session_stats') }}
+where
+    session_range < 0 or
+    true_range < session_range or
+    close_vs_range < 0 or
+    close_vs_range > 1 or
+    atr_5 < 0

--- a/services/orchestrator/src/dbt_project/tests/assert_stg_oanda_ticks_ask_gt_bid.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_stg_oanda_ticks_ask_gt_bid.sql
@@ -1,0 +1,3 @@
+select *
+from {{ ref('stg_oanda_ticks') }}
+where ask < bid

--- a/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_d1_ohlc_invariants.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_d1_ohlc_invariants.sql
@@ -1,0 +1,22 @@
+select *
+from {{ ref('stg_ohlc_d1') }}
+where
+    high < low or
+    high < open or
+    high < close or
+    low > open or
+    low > close or
+    bid_high < bid_low or
+    bid_high < bid_open or
+    bid_high < bid_close or
+    bid_low > bid_open or
+    bid_low > bid_close or
+    ask_high < ask_low or
+    ask_high < ask_open or
+    ask_high < ask_close or
+    ask_low > ask_open or
+    ask_low > ask_close or
+    ask_open < bid_open or
+    ask_high < bid_high or
+    ask_low < bid_low or
+    ask_close < bid_close

--- a/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_h1_ohlc_invariants.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_h1_ohlc_invariants.sql
@@ -1,0 +1,22 @@
+select *
+from {{ ref('stg_ohlc_h1') }}
+where
+    high < low or
+    high < open or
+    high < close or
+    low > open or
+    low > close or
+    bid_high < bid_low or
+    bid_high < bid_open or
+    bid_high < bid_close or
+    bid_low > bid_open or
+    bid_low > bid_close or
+    ask_high < ask_low or
+    ask_high < ask_open or
+    ask_high < ask_close or
+    ask_low > ask_open or
+    ask_low > ask_close or
+    ask_open < bid_open or
+    ask_high < bid_high or
+    ask_low < bid_low or
+    ask_close < bid_close

--- a/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_h4_ohlc_invariants.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_h4_ohlc_invariants.sql
@@ -1,0 +1,22 @@
+select *
+from {{ ref('stg_ohlc_h4') }}
+where
+    high < low or
+    high < open or
+    high < close or
+    low > open or
+    low > close or
+    bid_high < bid_low or
+    bid_high < bid_open or
+    bid_high < bid_close or
+    bid_low > bid_open or
+    bid_low > bid_close or
+    ask_high < ask_low or
+    ask_high < ask_open or
+    ask_high < ask_close or
+    ask_low > ask_open or
+    ask_low > ask_close or
+    ask_open < bid_open or
+    ask_high < bid_high or
+    ask_low < bid_low or
+    ask_close < bid_close

--- a/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_m15_ohlc_invariants.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_m15_ohlc_invariants.sql
@@ -1,0 +1,22 @@
+select *
+from {{ ref('stg_ohlc_m15') }}
+where
+    high < low or
+    high < open or
+    high < close or
+    low > open or
+    low > close or
+    bid_high < bid_low or
+    bid_high < bid_open or
+    bid_high < bid_close or
+    bid_low > bid_open or
+    bid_low > bid_close or
+    ask_high < ask_low or
+    ask_high < ask_open or
+    ask_high < ask_close or
+    ask_low > ask_open or
+    ask_low > ask_close or
+    ask_open < bid_open or
+    ask_high < bid_high or
+    ask_low < bid_low or
+    ask_close < bid_close

--- a/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_m1_ohlc_invariants.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_m1_ohlc_invariants.sql
@@ -1,0 +1,22 @@
+select *
+from {{ ref('stg_ohlc_m1') }}
+where
+    high < low or
+    high < open or
+    high < close or
+    low > open or
+    low > close or
+    bid_high < bid_low or
+    bid_high < bid_open or
+    bid_high < bid_close or
+    bid_low > bid_open or
+    bid_low > bid_close or
+    ask_high < ask_low or
+    ask_high < ask_open or
+    ask_high < ask_close or
+    ask_low > ask_open or
+    ask_low > ask_close or
+    ask_open < bid_open or
+    ask_high < bid_high or
+    ask_low < bid_low or
+    ask_close < bid_close

--- a/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_m5_ohlc_invariants.sql
+++ b/services/orchestrator/src/dbt_project/tests/assert_stg_ohlc_m5_ohlc_invariants.sql
@@ -1,0 +1,22 @@
+select *
+from {{ ref('stg_ohlc_m5') }}
+where
+    high < low or
+    high < open or
+    high < close or
+    low > open or
+    low > close or
+    bid_high < bid_low or
+    bid_high < bid_open or
+    bid_high < bid_close or
+    bid_low > bid_open or
+    bid_low > bid_close or
+    ask_high < ask_low or
+    ask_high < ask_open or
+    ask_high < ask_close or
+    ask_low > ask_open or
+    ask_low > ask_close or
+    ask_open < bid_open or
+    ask_high < bid_high or
+    ask_low < bid_low or
+    ask_close < bid_close


### PR DESCRIPTION
Add inbuilt tests for non-null values and uniqueness checking to relevant dbt models.

Uniqueness checking revealed a bug in 3 of the data models that was fixed in #49 

Add custom tests for ohlc invariants for all staging models as well as custom tests for gold model calculations. All tests passed.

Tests will run automatically on every dbt build (candle_builder currently delivers a file every 15 minutes that sensor will pick up to trigger build).

Closes #42 